### PR TITLE
GODRIVER-3522 Add support for the rawData option for time-series bucket access - PR1

### DIFF
--- a/internal/integration/unified/collection_operation_execution.go
+++ b/internal/integration/unified/collection_operation_execution.go
@@ -1526,6 +1526,8 @@ func createFindCursor(ctx context.Context, operation *operation) (*cursorResult,
 		case "maxAwaitTimeMS":
 			maxAwaitTimeMS := time.Duration(val.Int32()) * time.Millisecond
 			opts.SetMaxAwaitTime(maxAwaitTimeMS)
+		case "rawData":
+			opts.SetRawData(val.Boolean())
 		default:
 			return nil, fmt.Errorf("unrecognized find option %q", key)
 		}

--- a/internal/integration/unified/collection_operation_execution.go
+++ b/internal/integration/unified/collection_operation_execution.go
@@ -1324,6 +1324,8 @@ func executeReplaceOne(ctx context.Context, operation *operation) (*operationRes
 			opts.SetUpsert(val.Boolean())
 		case "let":
 			opts.SetLet(val.Document())
+		case "rawData":
+			opts.SetRawData(val.Boolean())
 		default:
 			return nil, fmt.Errorf("unrecognized replaceOne option %q", key)
 		}

--- a/internal/integration/unified/collection_operation_execution.go
+++ b/internal/integration/unified/collection_operation_execution.go
@@ -127,6 +127,8 @@ func executeBulkWrite(ctx context.Context, operation *operation) (*operationResu
 			}
 		case "let":
 			opts.SetLet(val.Document())
+		case "rawData":
+			opts.SetRawData(val.Boolean())
 		default:
 			return nil, fmt.Errorf("unrecognized bulkWrite option %q", key)
 		}

--- a/internal/integration/unified/collection_operation_execution.go
+++ b/internal/integration/unified/collection_operation_execution.go
@@ -854,6 +854,8 @@ func executeFindOneAndDelete(ctx context.Context, operation *operation) (*operat
 			opts.SetSort(val.Document())
 		case "let":
 			opts.SetLet(val.Document())
+		case "rawData":
+			opts.SetRawData(val.Boolean())
 		default:
 			return nil, fmt.Errorf("unrecognized findOneAndDelete option %q", key)
 		}
@@ -936,6 +938,8 @@ func executeFindOneAndReplace(ctx context.Context, operation *operation) (*opera
 			opts.SetSort(val.Document())
 		case "upsert":
 			opts.SetUpsert(val.Boolean())
+		case "rawData":
+			opts.SetRawData(val.Boolean())
 		default:
 			return nil, fmt.Errorf("unrecognized findOneAndReplace option %q", key)
 		}
@@ -1028,6 +1032,8 @@ func executeFindOneAndUpdate(ctx context.Context, operation *operation) (*operat
 			}
 		case "upsert":
 			opts.SetUpsert(val.Boolean())
+		case "rawData":
+			opts.SetRawData(val.Boolean())
 		default:
 			return nil, fmt.Errorf("unrecognized findOneAndUpdate option %q", key)
 		}

--- a/internal/integration/unified/crud_helpers.go
+++ b/internal/integration/unified/crud_helpers.go
@@ -67,6 +67,8 @@ func createUpdateManyArguments(args bson.Raw) (*updateArguments, *options.Update
 			}
 		case "upsert":
 			opts.SetUpsert(val.Boolean())
+		case "rawData":
+			opts.SetRawData(val.Boolean())
 		default:
 			return nil, nil, fmt.Errorf("unrecognized update option %q", key)
 		}
@@ -125,6 +127,8 @@ func createUpdateOneArguments(args bson.Raw) (*updateArguments, *options.UpdateO
 			opts.SetUpsert(val.Boolean())
 		case "sort":
 			opts.SetSort(val.Document())
+		case "rawData":
+			opts.SetRawData(val.Boolean())
 		default:
 			return nil, nil, fmt.Errorf("unrecognized update option %q", key)
 		}

--- a/mongo/bulk_write.go
+++ b/mongo/bulk_write.go
@@ -39,6 +39,7 @@ type bulkWrite struct {
 	writeConcern             *writeconcern.WriteConcern
 	result                   BulkWriteResult
 	let                      interface{}
+	rawData                  *bool
 }
 
 func (bw *bulkWrite) execute(ctx context.Context) error {
@@ -209,6 +210,10 @@ func (bw *bulkWrite) runInsert(ctx context.Context, batch bulkWriteBatch) (opera
 	}
 	op = op.Retry(retry)
 
+	if bw.rawData != nil {
+		op.RawData(*bw.rawData)
+	}
+
 	err := op.Execute(ctx)
 
 	return op.Result(), err
@@ -281,6 +286,10 @@ func (bw *bulkWrite) runDelete(ctx context.Context, batch bulkWriteBatch) (opera
 		retry = driver.RetryOncePerCommand
 	}
 	op = op.Retry(retry)
+
+	if bw.rawData != nil {
+		op.RawData(*bw.rawData)
+	}
 
 	err := op.Execute(ctx)
 
@@ -414,6 +423,10 @@ func (bw *bulkWrite) runUpdate(ctx context.Context, batch bulkWriteBatch) (opera
 		retry = driver.RetryOncePerCommand
 	}
 	op = op.Retry(retry)
+
+	if bw.rawData != nil {
+		op.RawData(*bw.rawData)
+	}
 
 	err := op.Execute(ctx)
 

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -244,6 +244,7 @@ func (coll *Collection) BulkWrite(ctx context.Context, models []WriteModel,
 		selector:                 selector,
 		writeConcern:             wc,
 		let:                      args.Let,
+		rawData:                  args.RawData,
 	}
 
 	err = op.execute(ctx)

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -1519,6 +1519,9 @@ func (coll *Collection) find(
 		}
 		op.Sort(sort)
 	}
+	if args.RawData != nil {
+		op = op.RawData(*args.RawData)
+	}
 	retry := driver.RetryNone
 	if coll.client.retryReads {
 		retry = driver.RetryOncePerCommand
@@ -1552,6 +1555,7 @@ func newFindArgsFromFindOneArgs(args *options.FindOneOptions) *options.FindOptio
 		v.ShowRecordID = args.ShowRecordID
 		v.Skip = args.Skip
 		v.Sort = args.Sort
+		v.RawData = args.RawData
 	}
 	return v
 }
@@ -1714,6 +1718,9 @@ func (coll *Collection) FindOneAndDelete(
 		}
 		op = op.Let(let)
 	}
+	if args.RawData != nil {
+		op = op.RawData(*args.RawData)
+	}
 
 	return coll.findAndModify(ctx, op)
 }
@@ -1810,6 +1817,9 @@ func (coll *Collection) FindOneAndReplace(
 			return &SingleResult{err: err}
 		}
 		op = op.Let(let)
+	}
+	if args.RawData != nil {
+		op = op.RawData(*args.RawData)
 	}
 
 	return coll.findAndModify(ctx, op)
@@ -1919,6 +1929,9 @@ func (coll *Collection) FindOneAndUpdate(
 			return &SingleResult{err: err}
 		}
 		op = op.Let(let)
+	}
+	if args.RawData != nil {
+		op = op.RawData(*args.RawData)
 	}
 
 	return coll.findAndModify(ctx, op)

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -691,6 +691,9 @@ func (coll *Collection) updateOrReplace(
 		}
 		op = op.Comment(comment)
 	}
+	if args.RawData != nil {
+		op = op.RawData(*args.RawData)
+	}
 	retry := driver.RetryNone
 	// retryable writes are only enabled updateOne/replaceOne operations
 	if !multi && coll.client.retryWrites {
@@ -785,6 +788,7 @@ func (coll *Collection) UpdateOne(
 		Hint:                     args.Hint,
 		Upsert:                   args.Upsert,
 		Let:                      args.Let,
+		RawData:                  args.RawData,
 	}
 
 	return coll.updateOrReplace(ctx, f, update, false, rrOne, true, args.Sort, updateOptions)
@@ -875,6 +879,7 @@ func (coll *Collection) ReplaceOne(
 		Hint:                     args.Hint,
 		Let:                      args.Let,
 		Comment:                  args.Comment,
+		RawData:                  args.RawData,
 	}
 
 	return coll.updateOrReplace(ctx, f, r, false, rrOne, false, args.Sort, updateOptions)

--- a/mongo/options/bulkwriteoptions.go
+++ b/mongo/options/bulkwriteoptions.go
@@ -18,6 +18,7 @@ type BulkWriteOptions struct {
 	Comment                  interface{}
 	Ordered                  *bool
 	Let                      interface{}
+	RawData                  *bool
 }
 
 // BulkWriteOptionsBuilder contains options to configure bulk write operations.
@@ -86,6 +87,18 @@ func (b *BulkWriteOptionsBuilder) SetBypassDocumentValidation(bypass bool) *Bulk
 func (b *BulkWriteOptionsBuilder) SetLet(let interface{}) *BulkWriteOptionsBuilder {
 	b.Opts = append(b.Opts, func(opts *BulkWriteOptions) error {
 		opts.Let = &let
+
+		return nil
+	})
+
+	return b
+}
+
+// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
+// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
+func (b *BulkWriteOptionsBuilder) SetRawData(rawData bool) *BulkWriteOptionsBuilder {
+	b.Opts = append(b.Opts, func(opts *BulkWriteOptions) error {
+		opts.RawData = &rawData
 
 		return nil
 	})

--- a/mongo/options/findoptions.go
+++ b/mongo/options/findoptions.go
@@ -35,6 +35,7 @@ type FindOptions struct {
 	Let             interface{}
 	Limit           *int64
 	NoCursorTimeout *bool
+	RawData         *bool
 }
 
 // FindOptionsBuilder represents functional options that configure an Findopts.
@@ -268,6 +269,18 @@ func (f *FindOptionsBuilder) SetSort(sort interface{}) *FindOptionsBuilder {
 	return f
 }
 
+// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
+// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
+func (f *FindOptionsBuilder) SetRawData(rawData bool) *FindOptionsBuilder {
+	f.Opts = append(f.Opts, func(opts *FindOptions) error {
+		opts.RawData = &rawData
+
+		return nil
+	})
+
+	return f
+}
+
 // FindOneOptions represents arguments that can be used to configure a FindOne
 // operation.
 //
@@ -285,6 +298,7 @@ type FindOneOptions struct {
 	ShowRecordID        *bool
 	Skip                *int64
 	Sort                interface{}
+	RawData             *bool
 }
 
 // FindOneOptionsBuilder represents functional options that configure an
@@ -436,6 +450,17 @@ func (f *FindOneOptionsBuilder) SetSort(sort interface{}) *FindOneOptionsBuilder
 	return f
 }
 
+// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
+// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
+func (f *FindOneOptionsBuilder) SetRawData(rawData bool) *FindOneOptionsBuilder {
+	f.Opts = append(f.Opts, func(opts *FindOneOptions) error {
+		opts.RawData = &rawData
+		return nil
+	})
+
+	return f
+}
+
 // FindOneAndReplaceOptions represents arguments that can be used to configure a
 // FindOneAndReplace instance.
 //
@@ -450,6 +475,7 @@ type FindOneAndReplaceOptions struct {
 	Upsert                   *bool
 	Hint                     interface{}
 	Let                      interface{}
+	RawData                  *bool
 }
 
 // FindOneAndReplaceOptionsBuilder contains options to perform a findAndModify
@@ -596,6 +622,18 @@ func (f *FindOneAndReplaceOptionsBuilder) SetLet(let interface{}) *FindOneAndRep
 	return f
 }
 
+// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
+// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
+func (f *FindOneAndReplaceOptionsBuilder) SetRawData(rawData bool) *FindOneAndReplaceOptionsBuilder {
+	f.Opts = append(f.Opts, func(opts *FindOneAndReplaceOptions) error {
+		opts.RawData = &rawData
+
+		return nil
+	})
+
+	return f
+}
+
 // FindOneAndUpdateOptions represents arguments that can be used to configure a
 // FindOneAndUpdate options.
 //
@@ -611,6 +649,7 @@ type FindOneAndUpdateOptions struct {
 	Upsert                   *bool
 	Hint                     interface{}
 	Let                      interface{}
+	RawData                  *bool
 }
 
 // FindOneAndUpdateOptionsBuilder contains options to configure a
@@ -771,6 +810,18 @@ func (f *FindOneAndUpdateOptionsBuilder) SetLet(let interface{}) *FindOneAndUpda
 	return f
 }
 
+// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
+// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
+func (f *FindOneAndUpdateOptionsBuilder) SetRawData(rawData bool) *FindOneAndUpdateOptionsBuilder {
+	f.Opts = append(f.Opts, func(opts *FindOneAndUpdateOptions) error {
+		opts.RawData = &rawData
+
+		return nil
+	})
+
+	return f
+}
+
 // FindOneAndDeleteOptions represents arguments that can be used to configure a
 // FindOneAndDelete operation.
 //
@@ -782,6 +833,7 @@ type FindOneAndDeleteOptions struct {
 	Sort       interface{}
 	Hint       interface{}
 	Let        interface{}
+	RawData    *bool
 }
 
 // FindOneAndDeleteOptionsBuilder contains options to configure delete
@@ -880,6 +932,18 @@ func (f *FindOneAndDeleteOptionsBuilder) SetHint(hint interface{}) *FindOneAndDe
 func (f *FindOneAndDeleteOptionsBuilder) SetLet(let interface{}) *FindOneAndDeleteOptionsBuilder {
 	f.Opts = append(f.Opts, func(opts *FindOneAndDeleteOptions) error {
 		opts.Let = let
+
+		return nil
+	})
+
+	return f
+}
+
+// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
+// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
+func (f *FindOneAndDeleteOptionsBuilder) SetRawData(rawData bool) *FindOneAndDeleteOptionsBuilder {
+	f.Opts = append(f.Opts, func(opts *FindOneAndDeleteOptions) error {
+		opts.RawData = &rawData
 
 		return nil
 	})

--- a/mongo/options/replaceoptions.go
+++ b/mongo/options/replaceoptions.go
@@ -18,6 +18,7 @@ type ReplaceOptions struct {
 	Upsert                   *bool
 	Let                      interface{}
 	Sort                     interface{}
+	RawData                  *bool
 }
 
 // ReplaceOptionsBuilder contains options to configure replace operations. Each
@@ -130,6 +131,18 @@ func (ro *ReplaceOptionsBuilder) SetLet(l interface{}) *ReplaceOptionsBuilder {
 func (ro *ReplaceOptionsBuilder) SetSort(s interface{}) *ReplaceOptionsBuilder {
 	ro.Opts = append(ro.Opts, func(opts *ReplaceOptions) error {
 		opts.Sort = s
+
+		return nil
+	})
+
+	return ro
+}
+
+// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
+// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
+func (ro *ReplaceOptionsBuilder) SetRawData(rawData bool) *ReplaceOptionsBuilder {
+	ro.Opts = append(ro.Opts, func(opts *ReplaceOptions) error {
+		opts.RawData = &rawData
 
 		return nil
 	})

--- a/mongo/options/updateoptions.go
+++ b/mongo/options/updateoptions.go
@@ -19,6 +19,7 @@ type UpdateOneOptions struct {
 	Upsert                   *bool
 	Let                      interface{}
 	Sort                     interface{}
+	RawData                  *bool
 }
 
 // UpdateOneOptionsBuilder contains options to configure UpdateOne operations.
@@ -152,6 +153,18 @@ func (uo *UpdateOneOptionsBuilder) SetSort(s interface{}) *UpdateOneOptionsBuild
 	return uo
 }
 
+// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
+// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
+func (uo *UpdateOneOptionsBuilder) SetRawData(rawData bool) *UpdateOneOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateOneOptions) error {
+		opts.RawData = &rawData
+
+		return nil
+	})
+
+	return uo
+}
+
 // UpdateManyOptions represents arguments that can be used to configure UpdateMany
 // operations.
 //
@@ -164,6 +177,7 @@ type UpdateManyOptions struct {
 	Hint                     interface{}
 	Upsert                   *bool
 	Let                      interface{}
+	RawData                  *bool
 }
 
 // UpdateManyOptionsBuilder contains options to configure UpdateMany operations.
@@ -275,6 +289,18 @@ func (uo *UpdateManyOptionsBuilder) SetUpsert(b bool) *UpdateManyOptionsBuilder 
 func (uo *UpdateManyOptionsBuilder) SetLet(l interface{}) *UpdateManyOptionsBuilder {
 	uo.Opts = append(uo.Opts, func(opts *UpdateManyOptions) error {
 		opts.Let = l
+
+		return nil
+	})
+
+	return uo
+}
+
+// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
+// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
+func (uo *UpdateManyOptionsBuilder) SetRawData(rawData bool) *UpdateManyOptionsBuilder {
+	uo.Opts = append(uo.Opts, func(opts *UpdateManyOptions) error {
+		opts.RawData = &rawData
 
 		return nil
 	})

--- a/x/mongo/driver/operation/find.go
+++ b/x/mongo/driver/operation/find.go
@@ -61,6 +61,7 @@ type Find struct {
 	result              driver.CursorResponse
 	serverAPI           *driver.ServerAPIOptions
 	timeout             *time.Duration
+	rawData             *bool
 	logger              *logger.Logger
 	omitMaxTimeMS       bool
 }
@@ -190,6 +191,10 @@ func (f *Find) command(dst []byte, desc description.SelectedServer) ([]byte, err
 	}
 	if f.tailable != nil {
 		dst = bsoncore.AppendBooleanElement(dst, "tailable", *f.tailable)
+	}
+	// Set rawData for 8.2+ servers.
+	if f.rawData != nil && desc.WireVersion != nil && driverutil.VersionRangeIncludes(*desc.WireVersion, 27) {
+		dst = bsoncore.AppendBooleanElement(dst, "rawData", *f.rawData)
 	}
 	return dst, nil
 }
@@ -562,6 +567,16 @@ func (f *Find) Authenticator(authenticator driver.Authenticator) *Find {
 	}
 
 	f.authenticator = authenticator
+	return f
+}
+
+// RawData sets the rawData to access timeseries data in the compressed format.
+func (f *Find) RawData(rawData bool) *Find {
+	if f == nil {
+		f = new(Find)
+	}
+
+	f.rawData = &rawData
 	return f
 }
 

--- a/x/mongo/driver/operation/find_and_modify.go
+++ b/x/mongo/driver/operation/find_and_modify.go
@@ -50,6 +50,7 @@ type FindAndModify struct {
 	serverAPI                *driver.ServerAPIOptions
 	let                      bsoncore.Document
 	timeout                  *time.Duration
+	rawData                  *bool
 
 	result FindAndModifyResult
 }
@@ -210,6 +211,10 @@ func (fam *FindAndModify) command(dst []byte, desc description.SelectedServer) (
 	}
 	if fam.let != nil {
 		dst = bsoncore.AppendDocumentElement(dst, "let", fam.let)
+	}
+	// Set rawData for 8.2+ servers.
+	if fam.rawData != nil && desc.WireVersion != nil && driverutil.VersionRangeIncludes(*desc.WireVersion, 27) {
+		dst = bsoncore.AppendBooleanElement(dst, "rawData", *fam.rawData)
 	}
 
 	return dst, nil
@@ -474,5 +479,15 @@ func (fam *FindAndModify) Authenticator(authenticator driver.Authenticator) *Fin
 	}
 
 	fam.authenticator = authenticator
+	return fam
+}
+
+// RawData sets the rawData to access timeseries data in the compressed format.
+func (fam *FindAndModify) RawData(rawData bool) *FindAndModify {
+	if fam == nil {
+		fam = new(FindAndModify)
+	}
+
+	fam.rawData = &rawData
 	return fam
 }

--- a/x/mongo/driver/operation/update.go
+++ b/x/mongo/driver/operation/update.go
@@ -46,6 +46,7 @@ type Update struct {
 	serverAPI                *driver.ServerAPIOptions
 	let                      bsoncore.Document
 	timeout                  *time.Duration
+	rawData                  *bool
 	logger                   *logger.Logger
 }
 
@@ -202,6 +203,10 @@ func (u *Update) command(dst []byte, desc description.SelectedServer) ([]byte, e
 	}
 	if u.let != nil {
 		dst = bsoncore.AppendDocumentElement(dst, "let", u.let)
+	}
+	// Set rawData for 8.2+ servers.
+	if u.rawData != nil && desc.WireVersion != nil && driverutil.VersionRangeIncludes(*desc.WireVersion, 27) {
+		dst = bsoncore.AppendBooleanElement(dst, "rawData", *u.rawData)
 	}
 
 	return dst, nil
@@ -420,5 +425,15 @@ func (u *Update) Authenticator(authenticator driver.Authenticator) *Update {
 	}
 
 	u.authenticator = authenticator
+	return u
+}
+
+// RawData sets the rawData to access timeseries data in the compressed format.
+func (u *Update) RawData(rawData bool) *Update {
+	if u == nil {
+		u = new(Update)
+	}
+
+	u.rawData = &rawData
 	return u
 }


### PR DESCRIPTION
GODRIVER-3522

## Summary
Add support for the `rawData` option for time-series bucket access - PR1
Stacked on the top of https://github.com/mongodb/mongo-go-driver/pull/2121

Add support for the following operations:
 - find
 - findAndModify
 - update/replace
 - collection bulkWrite

## Background & Motivation

<!--- Rationale for the pull request. -->
