### PR TITLE
GODRIVER-3522 Add support for the rawData option for time-series bucket access - PR2

### DIFF
--- a/internal/integration/unified/client_operation_execution.go
+++ b/internal/integration/unified/client_operation_execution.go
@@ -19,6 +19,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/xoptions"
 )
 
 // This file contains helpers to execute client operations.
@@ -236,7 +237,10 @@ func executeClientBulkWrite(ctx context.Context, operation *operation) (*operati
 			}
 			opts.SetWriteConcern(c)
 		case "rawData":
-			opts.SetRawData(val.Boolean())
+			err = xoptions.SetInternalClientBulkWriteOptions(opts, key, val.Boolean())
+			if err != nil {
+				return nil, err
+			}
 		default:
 			return nil, fmt.Errorf("unrecognized bulkWrite option %q", key)
 		}

--- a/internal/integration/unified/client_operation_execution.go
+++ b/internal/integration/unified/client_operation_execution.go
@@ -235,6 +235,8 @@ func executeClientBulkWrite(ctx context.Context, operation *operation) (*operati
 				return nil, err
 			}
 			opts.SetWriteConcern(c)
+		case "rawData":
+			opts.SetRawData(val.Boolean())
 		default:
 			return nil, fmt.Errorf("unrecognized bulkWrite option %q", key)
 		}

--- a/internal/integration/unified/collection_operation_execution.go
+++ b/internal/integration/unified/collection_operation_execution.go
@@ -241,6 +241,7 @@ func executeCreateIndex(ctx context.Context, operation *operation) (*operationRe
 
 	var keys bson.Raw
 	indexOpts := options.Index()
+	opts := options.CreateIndexes()
 
 	elems, err := operation.Arguments.Elements()
 	if err != nil {
@@ -295,6 +296,8 @@ func executeCreateIndex(ctx context.Context, operation *operation) (*operationRe
 			indexOpts.SetWeights(val.Document())
 		case "wildcardProjection":
 			indexOpts.SetWildcardProjection(val.Document())
+		case "rawData":
+			opts.SetRawData(val.Boolean())
 		default:
 			return nil, fmt.Errorf("unrecognized createIndex option %q", key)
 		}
@@ -307,7 +310,8 @@ func executeCreateIndex(ctx context.Context, operation *operation) (*operationRe
 		Keys:    keys,
 		Options: indexOpts,
 	}
-	name, err := coll.Indexes().CreateOne(ctx, model)
+
+	name, err := coll.Indexes().CreateOne(ctx, model, opts)
 	return newValueResult(bson.TypeString, bsoncore.AppendString(nil, name), err), nil
 }
 
@@ -624,6 +628,8 @@ func executeDropIndex(ctx context.Context, operation *operation) (*operationResu
 			// ensured an analogue exists, extend "skippedTestDescriptions" to avoid
 			// this error.
 			return nil, fmt.Errorf("the maxTimeMS collection option is not supported")
+		case "rawData":
+			dropIndexOpts.SetRawData(val.Boolean())
 		default:
 			return nil, fmt.Errorf("unrecognized dropIndex option %q", key)
 		}
@@ -1217,6 +1223,8 @@ func executeListIndexes(ctx context.Context, operation *operation) (*operationRe
 		switch key {
 		case "batchSize":
 			opts.SetBatchSize(val.Int32())
+		case "rawData":
+			opts.SetRawData(val.Boolean())
 		default:
 			return nil, fmt.Errorf("unrecognized listIndexes option: %q", key)
 		}

--- a/internal/integration/unified/collection_operation_execution.go
+++ b/internal/integration/unified/collection_operation_execution.go
@@ -297,7 +297,10 @@ func executeCreateIndex(ctx context.Context, operation *operation) (*operationRe
 		case "wildcardProjection":
 			indexOpts.SetWildcardProjection(val.Document())
 		case "rawData":
-			opts.SetRawData(val.Boolean())
+			err = xoptions.SetInternalCreateIndexesOptions(opts, key, val.Boolean())
+			if err != nil {
+				return nil, err
+			}
 		default:
 			return nil, fmt.Errorf("unrecognized createIndex option %q", key)
 		}
@@ -629,7 +632,10 @@ func executeDropIndex(ctx context.Context, operation *operation) (*operationResu
 			// this error.
 			return nil, fmt.Errorf("the maxTimeMS collection option is not supported")
 		case "rawData":
-			dropIndexOpts.SetRawData(val.Boolean())
+			err = xoptions.SetInternalDropIndexesOptions(dropIndexOpts, key, val.Boolean())
+			if err != nil {
+				return nil, err
+			}
 		default:
 			return nil, fmt.Errorf("unrecognized dropIndex option %q", key)
 		}
@@ -1224,7 +1230,10 @@ func executeListIndexes(ctx context.Context, operation *operation) (*operationRe
 		case "batchSize":
 			opts.SetBatchSize(val.Int32())
 		case "rawData":
-			opts.SetRawData(val.Boolean())
+			err = xoptions.SetInternalListIndexesOptions(opts, key, val.Boolean())
+			if err != nil {
+				return nil, err
+			}
 		default:
 			return nil, fmt.Errorf("unrecognized listIndexes option: %q", key)
 		}

--- a/internal/integration/unified/crud_helpers.go
+++ b/internal/integration/unified/crud_helpers.go
@@ -174,7 +174,10 @@ func createListCollectionsArguments(args bson.Raw) (*listCollectionsArguments, e
 		case "nameOnly":
 			lca.opts.SetNameOnly(val.Boolean())
 		case "rawData":
-			lca.opts.SetRawData(val.Boolean())
+			err := xoptions.SetInternalListCollectionsOptions(lca.opts, key, val.Boolean())
+			if err != nil {
+				return nil, err
+			}
 		default:
 			return nil, fmt.Errorf("unrecognized listCollections option %q", key)
 		}

--- a/internal/integration/unified/crud_helpers.go
+++ b/internal/integration/unified/crud_helpers.go
@@ -173,6 +173,8 @@ func createListCollectionsArguments(args bson.Raw) (*listCollectionsArguments, e
 			lca.filter = val.Document()
 		case "nameOnly":
 			lca.opts.SetNameOnly(val.Boolean())
+		case "rawData":
+			lca.opts.SetRawData(val.Boolean())
 		default:
 			return nil, fmt.Errorf("unrecognized listCollections option %q", key)
 		}

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -956,6 +956,7 @@ func (c *Client) BulkWrite(ctx context.Context, writes []ClientBulkWrite,
 		client:                   c,
 		selector:                 selector,
 		writeConcern:             wc,
+		rawData:                  bwo.RawData,
 	}
 	if bwo.VerboseResults == nil || !(*bwo.VerboseResults) {
 		op.errorsOnly = true

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -18,6 +18,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/internal/httputil"
 	"go.mongodb.org/mongo-driver/v2/internal/logger"
 	"go.mongodb.org/mongo-driver/v2/internal/mongoutil"
+	"go.mongodb.org/mongo-driver/v2/internal/optionsutil"
 	"go.mongodb.org/mongo-driver/v2/internal/ptrutil"
 	"go.mongodb.org/mongo-driver/v2/internal/serverselector"
 	"go.mongodb.org/mongo-driver/v2/internal/uuid"
@@ -956,7 +957,11 @@ func (c *Client) BulkWrite(ctx context.Context, writes []ClientBulkWrite,
 		client:                   c,
 		selector:                 selector,
 		writeConcern:             wc,
-		rawData:                  bwo.RawData,
+	}
+	if rawDataOpt := optionsutil.Value(bwo.Internal, "rawData"); rawDataOpt != nil {
+		if rawData, ok := rawDataOpt.(bool); ok {
+			op.rawData = &rawData
+		}
 	}
 	if bwo.VerboseResults == nil || !(*bwo.VerboseResults) {
 		op.errorsOnly = true

--- a/mongo/client_bulk_write.go
+++ b/mongo/client_bulk_write.go
@@ -44,6 +44,7 @@ type clientBulkWrite struct {
 	client                   *Client
 	selector                 description.ServerSelector
 	writeConcern             *writeconcern.WriteConcern
+	rawData                  *bool
 
 	result ClientBulkWriteResult
 }
@@ -142,6 +143,10 @@ func (bw *clientBulkWrite) newCommand() func([]byte, description.SelectedServer)
 				return nil, err
 			}
 			dst = bsoncore.AppendDocumentElement(dst, "let", let)
+		}
+		// Set rawData for 8.2+ servers.
+		if bw.rawData != nil && desc.WireVersion != nil && driverutil.VersionRangeIncludes(*desc.WireVersion, 27) {
+			dst = bsoncore.AppendBooleanElement(dst, "rawData", *bw.rawData)
 		}
 		return dst, nil
 	}

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -487,6 +487,9 @@ func (db *Database) ListCollections(
 	if args.AuthorizedCollections != nil {
 		op = op.AuthorizedCollections(*args.AuthorizedCollections)
 	}
+	if args.RawData != nil {
+		op = op.RawData(*args.RawData)
+	}
 
 	retry := driver.RetryNone
 	if db.client.retryReads {

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -16,6 +16,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/internal/csfle"
 	"go.mongodb.org/mongo-driver/v2/internal/csot"
 	"go.mongodb.org/mongo-driver/v2/internal/mongoutil"
+	"go.mongodb.org/mongo-driver/v2/internal/optionsutil"
 	"go.mongodb.org/mongo-driver/v2/internal/serverselector"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/mongo/readconcern"
@@ -487,8 +488,10 @@ func (db *Database) ListCollections(
 	if args.AuthorizedCollections != nil {
 		op = op.AuthorizedCollections(*args.AuthorizedCollections)
 	}
-	if args.RawData != nil {
-		op = op.RawData(*args.RawData)
+	if rawDataOpt := optionsutil.Value(args.Internal, "rawData"); rawDataOpt != nil {
+		if rawData, ok := rawDataOpt.(bool); ok {
+			op = op.RawData(rawData)
+		}
 	}
 
 	retry := driver.RetryNone

--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 
 	"go.mongodb.org/mongo-driver/v2/internal/mongoutil"
+	"go.mongodb.org/mongo-driver/v2/internal/optionsutil"
 	"go.mongodb.org/mongo-driver/v2/internal/serverselector"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
@@ -101,8 +102,10 @@ func (iv IndexView) List(ctx context.Context, opts ...options.Lister[options.Lis
 		op = op.BatchSize(*args.BatchSize)
 		cursorOpts.BatchSize = *args.BatchSize
 	}
-	if args.RawData != nil {
-		op = op.RawData(*args.RawData)
+	if rawDataOpt := optionsutil.Value(args.Internal, "rawData"); rawDataOpt != nil {
+		if rawData, ok := rawDataOpt.(bool); ok {
+			op = op.RawData(rawData)
+		}
 	}
 
 	retry := driver.RetryNone
@@ -282,8 +285,10 @@ func (iv IndexView) CreateMany(
 
 		op.CommitQuorum(commitQuorum)
 	}
-	if args.RawData != nil {
-		op = op.RawData(*args.RawData)
+	if rawDataOpt := optionsutil.Value(args.Internal, "rawData"); rawDataOpt != nil {
+		if rawData, ok := rawDataOpt.(bool); ok {
+			op = op.RawData(rawData)
+		}
 	}
 
 	_, err = processWriteError(op.Execute(ctx))
@@ -419,8 +424,10 @@ func (iv IndexView) drop(ctx context.Context, index any, opts ...options.Lister[
 		Deployment(iv.coll.client.deployment).ServerAPI(iv.coll.client.serverAPI).
 		Timeout(iv.coll.client.timeout).Crypt(iv.coll.client.cryptFLE).Authenticator(iv.coll.client.authenticator)
 
-	if args.RawData != nil {
-		op = op.RawData(*args.RawData)
+	if rawDataOpt := optionsutil.Value(args.Internal, "rawData"); rawDataOpt != nil {
+		if rawData, ok := rawDataOpt.(bool); ok {
+			op = op.RawData(rawData)
+		}
 	}
 
 	err = op.Execute(ctx)

--- a/mongo/options/clientbulkwriteoptions.go
+++ b/mongo/options/clientbulkwriteoptions.go
@@ -7,6 +7,7 @@
 package options
 
 import (
+	"go.mongodb.org/mongo-driver/v2/internal/optionsutil"
 	"go.mongodb.org/mongo-driver/v2/mongo/writeconcern"
 )
 
@@ -19,8 +20,11 @@ type ClientBulkWriteOptions struct {
 	Ordered                  *bool
 	Let                      interface{}
 	WriteConcern             *writeconcern.WriteConcern
-	RawData                  *bool
 	VerboseResults           *bool
+
+	// Deprecated: This option is for internal use only and should not be set. It may be changed or removed in any
+	// release.
+	Internal optionsutil.Options
 }
 
 // ClientBulkWriteOptionsBuilder contains options to configure client-level bulk
@@ -102,18 +106,6 @@ func (b *ClientBulkWriteOptionsBuilder) SetLet(let interface{}) *ClientBulkWrite
 func (b *ClientBulkWriteOptionsBuilder) SetWriteConcern(wc *writeconcern.WriteConcern) *ClientBulkWriteOptionsBuilder {
 	b.Opts = append(b.Opts, func(opts *ClientBulkWriteOptions) error {
 		opts.WriteConcern = wc
-
-		return nil
-	})
-
-	return b
-}
-
-// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
-// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
-func (b *ClientBulkWriteOptionsBuilder) SetRawData(rawData bool) *ClientBulkWriteOptionsBuilder {
-	b.Opts = append(b.Opts, func(opts *ClientBulkWriteOptions) error {
-		opts.RawData = &rawData
 
 		return nil
 	})

--- a/mongo/options/clientbulkwriteoptions.go
+++ b/mongo/options/clientbulkwriteoptions.go
@@ -19,6 +19,7 @@ type ClientBulkWriteOptions struct {
 	Ordered                  *bool
 	Let                      interface{}
 	WriteConcern             *writeconcern.WriteConcern
+	RawData                  *bool
 	VerboseResults           *bool
 }
 
@@ -101,6 +102,18 @@ func (b *ClientBulkWriteOptionsBuilder) SetLet(let interface{}) *ClientBulkWrite
 func (b *ClientBulkWriteOptionsBuilder) SetWriteConcern(wc *writeconcern.WriteConcern) *ClientBulkWriteOptionsBuilder {
 	b.Opts = append(b.Opts, func(opts *ClientBulkWriteOptions) error {
 		opts.WriteConcern = wc
+
+		return nil
+	})
+
+	return b
+}
+
+// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
+// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
+func (b *ClientBulkWriteOptionsBuilder) SetRawData(rawData bool) *ClientBulkWriteOptionsBuilder {
+	b.Opts = append(b.Opts, func(opts *ClientBulkWriteOptions) error {
+		opts.RawData = &rawData
 
 		return nil
 	})

--- a/mongo/options/indexoptions.go
+++ b/mongo/options/indexoptions.go
@@ -12,6 +12,7 @@ package options
 // See corresponding setter methods for documentation.
 type CreateIndexesOptions struct {
 	CommitQuorum interface{}
+	RawData      *bool
 }
 
 // CreateIndexesOptionsBuilder contains options to create indexes. Each option
@@ -119,9 +120,23 @@ func (c *CreateIndexesOptionsBuilder) SetCommitQuorumVotingMembers() *CreateInde
 	return c
 }
 
+// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
+// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
+func (c *CreateIndexesOptionsBuilder) SetRawData(rawData bool) *CreateIndexesOptionsBuilder {
+	c.Opts = append(c.Opts, func(opts *CreateIndexesOptions) error {
+		opts.RawData = &rawData
+
+		return nil
+	})
+
+	return c
+}
+
 // DropIndexesOptions represents arguments that can be used to configure
 // IndexView.DropOne and IndexView.DropAll operations.
-type DropIndexesOptions struct{}
+type DropIndexesOptions struct {
+	RawData *bool
+}
 
 // DropIndexesOptionsBuilder contains options to configure dropping indexes.
 // Each option can be set through setter functions. See documentation for each
@@ -140,12 +155,25 @@ func (d *DropIndexesOptionsBuilder) List() []func(*DropIndexesOptions) error {
 	return d.Opts
 }
 
+// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
+// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
+func (d *DropIndexesOptionsBuilder) SetRawData(rawData bool) *DropIndexesOptionsBuilder {
+	d.Opts = append(d.Opts, func(opts *DropIndexesOptions) error {
+		opts.RawData = &rawData
+
+		return nil
+	})
+
+	return d
+}
+
 // ListIndexesOptions represents arguments that can be used to configure an
 // IndexView.List operation.
 //
 // See corresponding setter methods for documentation.
 type ListIndexesOptions struct {
 	BatchSize *int32
+	RawData   *bool
 }
 
 // ListIndexesOptionsBuilder contains options to configure count operations. Each
@@ -170,6 +198,18 @@ func (l *ListIndexesOptionsBuilder) List() []func(*ListIndexesOptions) error {
 func (l *ListIndexesOptionsBuilder) SetBatchSize(i int32) *ListIndexesOptionsBuilder {
 	l.Opts = append(l.Opts, func(opts *ListIndexesOptions) error {
 		opts.BatchSize = &i
+
+		return nil
+	})
+
+	return l
+}
+
+// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
+// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
+func (l *ListIndexesOptionsBuilder) SetRawData(rawData bool) *ListIndexesOptionsBuilder {
+	l.Opts = append(l.Opts, func(opts *ListIndexesOptions) error {
+		opts.RawData = &rawData
 
 		return nil
 	})

--- a/mongo/options/indexoptions.go
+++ b/mongo/options/indexoptions.go
@@ -6,13 +6,18 @@
 
 package options
 
+import "go.mongodb.org/mongo-driver/v2/internal/optionsutil"
+
 // CreateIndexesOptions represents arguments that can be used to configure
 // IndexView.CreateOne and IndexView.CreateMany operations.
 //
 // See corresponding setter methods for documentation.
 type CreateIndexesOptions struct {
 	CommitQuorum interface{}
-	RawData      *bool
+
+	// Deprecated: This option is for internal use only and should not be set. It may be changed or removed in any
+	// release.
+	Internal optionsutil.Options
 }
 
 // CreateIndexesOptionsBuilder contains options to create indexes. Each option
@@ -120,22 +125,12 @@ func (c *CreateIndexesOptionsBuilder) SetCommitQuorumVotingMembers() *CreateInde
 	return c
 }
 
-// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
-// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
-func (c *CreateIndexesOptionsBuilder) SetRawData(rawData bool) *CreateIndexesOptionsBuilder {
-	c.Opts = append(c.Opts, func(opts *CreateIndexesOptions) error {
-		opts.RawData = &rawData
-
-		return nil
-	})
-
-	return c
-}
-
 // DropIndexesOptions represents arguments that can be used to configure
 // IndexView.DropOne and IndexView.DropAll operations.
 type DropIndexesOptions struct {
-	RawData *bool
+	// Deprecated: This option is for internal use only and should not be set. It may be changed or removed in any
+	// release.
+	Internal optionsutil.Options
 }
 
 // DropIndexesOptionsBuilder contains options to configure dropping indexes.
@@ -155,25 +150,16 @@ func (d *DropIndexesOptionsBuilder) List() []func(*DropIndexesOptions) error {
 	return d.Opts
 }
 
-// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
-// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
-func (d *DropIndexesOptionsBuilder) SetRawData(rawData bool) *DropIndexesOptionsBuilder {
-	d.Opts = append(d.Opts, func(opts *DropIndexesOptions) error {
-		opts.RawData = &rawData
-
-		return nil
-	})
-
-	return d
-}
-
 // ListIndexesOptions represents arguments that can be used to configure an
 // IndexView.List operation.
 //
 // See corresponding setter methods for documentation.
 type ListIndexesOptions struct {
 	BatchSize *int32
-	RawData   *bool
+
+	// Deprecated: This option is for internal use only and should not be set. It may be changed or removed in any
+	// release.
+	Internal optionsutil.Options
 }
 
 // ListIndexesOptionsBuilder contains options to configure count operations. Each
@@ -198,18 +184,6 @@ func (l *ListIndexesOptionsBuilder) List() []func(*ListIndexesOptions) error {
 func (l *ListIndexesOptionsBuilder) SetBatchSize(i int32) *ListIndexesOptionsBuilder {
 	l.Opts = append(l.Opts, func(opts *ListIndexesOptions) error {
 		opts.BatchSize = &i
-
-		return nil
-	})
-
-	return l
-}
-
-// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
-// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
-func (l *ListIndexesOptionsBuilder) SetRawData(rawData bool) *ListIndexesOptionsBuilder {
-	l.Opts = append(l.Opts, func(opts *ListIndexesOptions) error {
-		opts.RawData = &rawData
 
 		return nil
 	})

--- a/mongo/options/listcollectionsoptions.go
+++ b/mongo/options/listcollectionsoptions.go
@@ -6,6 +6,8 @@
 
 package options
 
+import "go.mongodb.org/mongo-driver/v2/internal/optionsutil"
+
 // ListCollectionsOptions represents arguments that can be used to configure a
 // ListCollections operation.
 //
@@ -14,7 +16,10 @@ type ListCollectionsOptions struct {
 	NameOnly              *bool
 	BatchSize             *int32
 	AuthorizedCollections *bool
-	RawData               *bool
+
+	// Deprecated: This option is for internal use only and should not be set. It may be changed or removed in any
+	// release.
+	Internal optionsutil.Options
 }
 
 // ListCollectionsOptionsBuilder contains options to configure list collection
@@ -65,18 +70,6 @@ func (lc *ListCollectionsOptionsBuilder) SetBatchSize(size int32) *ListCollectio
 func (lc *ListCollectionsOptionsBuilder) SetAuthorizedCollections(b bool) *ListCollectionsOptionsBuilder {
 	lc.Opts = append(lc.Opts, func(opts *ListCollectionsOptions) error {
 		opts.AuthorizedCollections = &b
-
-		return nil
-	})
-
-	return lc
-}
-
-// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
-// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
-func (lc *ListCollectionsOptionsBuilder) SetRawData(rawData bool) *ListCollectionsOptionsBuilder {
-	lc.Opts = append(lc.Opts, func(opts *ListCollectionsOptions) error {
-		opts.RawData = &rawData
 
 		return nil
 	})

--- a/mongo/options/listcollectionsoptions.go
+++ b/mongo/options/listcollectionsoptions.go
@@ -14,6 +14,7 @@ type ListCollectionsOptions struct {
 	NameOnly              *bool
 	BatchSize             *int32
 	AuthorizedCollections *bool
+	RawData               *bool
 }
 
 // ListCollectionsOptionsBuilder contains options to configure list collection
@@ -64,6 +65,18 @@ func (lc *ListCollectionsOptionsBuilder) SetBatchSize(size int32) *ListCollectio
 func (lc *ListCollectionsOptionsBuilder) SetAuthorizedCollections(b bool) *ListCollectionsOptionsBuilder {
 	lc.Opts = append(lc.Opts, func(opts *ListCollectionsOptions) error {
 		opts.AuthorizedCollections = &b
+
+		return nil
+	})
+
+	return lc
+}
+
+// SetRawData sets the value for the RawData field. If true, it allows the CRUD operations to access timeseries
+// collections on the bucket-level. This option is only valid for MongoDB versions >= 9.0. The default value is false.
+func (lc *ListCollectionsOptionsBuilder) SetRawData(rawData bool) *ListCollectionsOptionsBuilder {
+	lc.Opts = append(lc.Opts, func(opts *ListCollectionsOptions) error {
+		opts.RawData = &rawData
 
 		return nil
 	})

--- a/x/mongo/driver/xoptions/options.go
+++ b/x/mongo/driver/xoptions/options.go
@@ -86,6 +86,27 @@ func SetInternalBulkWriteOptions(a *options.BulkWriteOptionsBuilder, key string,
 	return nil
 }
 
+// SetInternalClientBulkWriteOptions sets internal options for ClientBulkWriteOptions.
+func SetInternalClientBulkWriteOptions(a *options.ClientBulkWriteOptionsBuilder, key string, option any) error {
+	typeErrFunc := func(t string) error {
+		return fmt.Errorf("unexpected type for %q: %T is not %s", key, option, t)
+	}
+	switch key {
+	case "rawData":
+		b, ok := option.(bool)
+		if !ok {
+			return typeErrFunc("bool")
+		}
+		a.Opts = append(a.Opts, func(opts *options.ClientBulkWriteOptions) error {
+			opts.Internal = optionsutil.WithValue(opts.Internal, key, b)
+			return nil
+		})
+	default:
+		return fmt.Errorf("unsupported option: %q", key)
+	}
+	return nil
+}
+
 // SetInternalCountOptions sets internal options for CountOptions.
 func SetInternalCountOptions(a *options.CountOptionsBuilder, key string, option any) error {
 	typeErrFunc := func(t string) error {
@@ -98,6 +119,27 @@ func SetInternalCountOptions(a *options.CountOptionsBuilder, key string, option 
 			return typeErrFunc("bool")
 		}
 		a.Opts = append(a.Opts, func(opts *options.CountOptions) error {
+			opts.Internal = optionsutil.WithValue(opts.Internal, key, b)
+			return nil
+		})
+	default:
+		return fmt.Errorf("unsupported option: %q", key)
+	}
+	return nil
+}
+
+// SetInternalCreateIndexesOptions sets internal options for CreateIndexesOptions.
+func SetInternalCreateIndexesOptions(a *options.CreateIndexesOptionsBuilder, key string, option any) error {
+	typeErrFunc := func(t string) error {
+		return fmt.Errorf("unexpected type for %q: %T is not %s", key, option, t)
+	}
+	switch key {
+	case "rawData":
+		b, ok := option.(bool)
+		if !ok {
+			return typeErrFunc("bool")
+		}
+		a.Opts = append(a.Opts, func(opts *options.CreateIndexesOptions) error {
 			opts.Internal = optionsutil.WithValue(opts.Internal, key, b)
 			return nil
 		})
@@ -161,6 +203,27 @@ func SetInternalDistinctOptions(a *options.DistinctOptionsBuilder, key string, o
 			return typeErrFunc("bool")
 		}
 		a.Opts = append(a.Opts, func(opts *options.DistinctOptions) error {
+			opts.Internal = optionsutil.WithValue(opts.Internal, key, b)
+			return nil
+		})
+	default:
+		return fmt.Errorf("unsupported option: %q", key)
+	}
+	return nil
+}
+
+// SetInternalDropIndexesOptions sets internal options for DropIndexesOptions.
+func SetInternalDropIndexesOptions(a *options.DropIndexesOptionsBuilder, key string, option any) error {
+	typeErrFunc := func(t string) error {
+		return fmt.Errorf("unexpected type for %q: %T is not %s", key, option, t)
+	}
+	switch key {
+	case "rawData":
+		b, ok := option.(bool)
+		if !ok {
+			return typeErrFunc("bool")
+		}
+		a.Opts = append(a.Opts, func(opts *options.DropIndexesOptions) error {
 			opts.Internal = optionsutil.WithValue(opts.Internal, key, b)
 			return nil
 		})
@@ -329,6 +392,48 @@ func SetInternalInsertOneOptions(a *options.InsertOneOptionsBuilder, key string,
 			return typeErrFunc("bool")
 		}
 		a.Opts = append(a.Opts, func(opts *options.InsertOneOptions) error {
+			opts.Internal = optionsutil.WithValue(opts.Internal, key, b)
+			return nil
+		})
+	default:
+		return fmt.Errorf("unsupported option: %q", key)
+	}
+	return nil
+}
+
+// SetInternalListCollectionsOptions sets internal options for ListCollectionsOptions.
+func SetInternalListCollectionsOptions(a *options.ListCollectionsOptionsBuilder, key string, option any) error {
+	typeErrFunc := func(t string) error {
+		return fmt.Errorf("unexpected type for %q: %T is not %s", key, option, t)
+	}
+	switch key {
+	case "rawData":
+		b, ok := option.(bool)
+		if !ok {
+			return typeErrFunc("bool")
+		}
+		a.Opts = append(a.Opts, func(opts *options.ListCollectionsOptions) error {
+			opts.Internal = optionsutil.WithValue(opts.Internal, key, b)
+			return nil
+		})
+	default:
+		return fmt.Errorf("unsupported option: %q", key)
+	}
+	return nil
+}
+
+// SetInternalListIndexesOptions sets internal options for ListIndexesOptions.
+func SetInternalListIndexesOptions(a *options.ListIndexesOptionsBuilder, key string, option any) error {
+	typeErrFunc := func(t string) error {
+		return fmt.Errorf("unexpected type for %q: %T is not %s", key, option, t)
+	}
+	switch key {
+	case "rawData":
+		b, ok := option.(bool)
+		if !ok {
+			return typeErrFunc("bool")
+		}
+		a.Opts = append(a.Opts, func(opts *options.ListIndexesOptions) error {
 			opts.Internal = optionsutil.WithValue(opts.Internal, key, b)
 			return nil
 		})


### PR DESCRIPTION
GODRIVER-3522

## Summary
Add support for the rawData option for time-series bucket access - PR2
Stacked on the top of https://github.com/mongodb/mongo-go-driver/pull/2123

Add support for the following operations:
 - client bulkWrite
 - listCollections
 - index operations

## Background & Motivation

<!--- Rationale for the pull request. -->
